### PR TITLE
Specify that geotransform must be a tuple

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -46,7 +46,8 @@ Geotransform
 -----------------------------------
 
 A **geotransform** is a six element array which determines where in a
-projection a RichDEM array's data is located, as well as the cell sizes.
+projection a RichDEM array's data is located, as well as the cell sizes. In
+python, the geotransform must be a 6 element tuple.
 
 Typically, the geotransform is an affine transform consisting of six
 coefficients which map pixel/line coordinates into a georeferenced space using


### PR DESCRIPTION
It took me a while to realize that, although the geotransform is said to be an "array", making it a numpy.array causes errors.

Thanks for your work on this great module!