### PR TITLE
Update setup.cfg

### DIFF
--- a/wrappers/pyrichdem/setup.cfg
+++ b/wrappers/pyrichdem/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 packager = Richard Barnes <rbarnes@umn.edu>
 
 [bdist_wheel]


### PR DESCRIPTION
change dash to underscore (setuptools depreciation).

Was running into an issue when installing python wrappers due to setuptools depreciation of dash-seperated files