### PR TITLE
Supporting wheels for Windows and MacOS

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -27,6 +27,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: cibw-sdist
-        path: dist/*.tar.gz
+        path: ./wrappers/pyrichdem/dist/*.tar.gz
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./wheelhouse/*.whl
+          path: ./wrappers/pyrichdem/wheelhouse/*.whl
 
   upload_all:
     needs: [build_wheels, make_sdist]

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -40,14 +40,12 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
-        with:
-          python-version: '3.9'
 
       - name: Install cibuildwheel and other dependencies
-        run: python -m pip install cibuildwheel==2.21.3 pyOpenSSL ndg-httpsclient pyasn1
+        run: python -m pip install cibuildwheel==2.21.3
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9" python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -45,7 +45,7 @@ jobs:
         run: python -m pip install cibuildwheel==2.21.3
 
       - name: Build wheels
-        run: CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9" python -m cibuildwheel --output-dir wheelhouse
+        run: CIBW_PROJECT_REQUIRES_PYTHON=">=3.9" python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -38,9 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      steps:
-      - uses: actions/checkout@v4
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
         env:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -38,14 +38,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Used to host cibuildwheel
-      - uses: actions/setup-python@v5
-
-      - name: Install cibuildwheel and other dependencies
-        run: python -m pip install cibuildwheel==2.21.3
+      steps:
+      - uses: actions/checkout@v4
 
       - name: Build wheels
-        run: CIBW_PROJECT_REQUIRES_PYTHON=">=3.9" python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.21.3
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
+        with:
+          package-dir: ./wrappers/pyrichdem
+          output-dir: ./wrappers/pyrichdem/wheelhouse
+          config-file: "{package}/pyproject.toml"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -6,6 +6,9 @@ jobs:
   make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./wrappers/pyrichdem
     steps:
     - uses: actions/checkout@v4
       with:
@@ -27,6 +30,9 @@ jobs:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+    defaults:
+      run:
+        working-directory: ./wrappers/pyrichdem
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -3,7 +3,7 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-   make_sdist:
+  make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -34,7 +34,7 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.6'
+          python-version: '3.9'
 
       - name: Install cibuildwheel and other dependencies
         run: python -m pip install cibuildwheel==2.21.3 pyOpenSSL ndg-httpsclient pyasn1

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,64 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+   make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Optional, use if you use setuptools_scm
+        submodules: true  # Optional, use if you have submodules
+
+    - name: Build SDist
+      run: pipx run build --sdist
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: cibw-sdist
+        path: dist/*.tar.gz
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.6'
+
+      - name: Install cibuildwheel and other dependencies
+        run: python -m pip install cibuildwheel==2.21.3 pyOpenSSL ndg-httpsclient pyasn1
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  upload_all:
+    needs: [build_wheels, make_sdist]
+    environment: pypi
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: cibw-*
+        path: dist
+        merge-multiple: true
+
+    - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
I was wondering whether you would consider distributing wheels for other platforms besides Linux on Pypi. 

The reasoning is as follows. Colleagues of mine are developing a package that depends on richdem (a QGIS plugin). However, most users of this software will be using Windows and some MacOS, which can make installing richdem a bit of a pain. Inserting conda environments into the mix is not compatible with the way these plugins are installed. Therefore, it would be nice to simply be able to pip install on any platform. Currently, the package they are developing already does this by using a locally built wheel hosted on a local artifact repository. I figure it would be better if wheels for all platforms would be supported upstream.

Here is a proposal, though it will probably have to be iterated on quite a bit to get it to work properly as it's mostly copy-paste from documentation at this stage. If you would consider switching to Github actions for building and publishing wheels, all of the major OSs and architectures are supported; as far as I could tell travis does not support MacOS runners. To minimize hackyness I propose to test out [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/deliver-to-pypi/#github-actions).